### PR TITLE
New Password challenge fix

### DIFF
--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -288,7 +288,7 @@ class AWSSRP:
 
             if tokens["ChallengeName"] == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
                 challenge_response.update(
-                    {"USERNAME": auth_params["USERNAME"], "NEW_PASSWORD": new_password,}
+                    {"USERNAME": auth_params["USERNAME"], "NEW_PASSWORD": new_password}
                 )
                 new_password_response = boto_client.respond_to_auth_challenge(
                     ClientId=self.client_id,

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -287,10 +287,9 @@ class AWSSRP:
             )
 
             if tokens["ChallengeName"] == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
-                challenge_response.update({
-                    "USERNAME": auth_params["USERNAME"],
-                    "NEW_PASSWORD": new_password,
-                })
+                challenge_response.update(
+                    {"USERNAME": auth_params["USERNAME"], "NEW_PASSWORD": new_password,}
+                )
                 new_password_response = boto_client.respond_to_auth_challenge(
                     ClientId=self.client_id,
                     ChallengeName=self.NEW_PASSWORD_REQUIRED_CHALLENGE,

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -287,10 +287,10 @@ class AWSSRP:
             )
 
             if tokens["ChallengeName"] == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
-                challenge_response = {
+                challenge_response.update({
                     "USERNAME": auth_params["USERNAME"],
                     "NEW_PASSWORD": new_password,
-                }
+                })
                 new_password_response = boto_client.respond_to_auth_challenge(
                     ClientId=self.client_id,
                     ChallengeName=self.NEW_PASSWORD_REQUIRED_CHALLENGE,


### PR DESCRIPTION
New password Challenge requires parameters initiate_auth request. Without them we get:
```
botocore.errorfactory.NotAuthorizedException: An error occurred (NotAuthorizedException) when calling the RespondToAuthChallenge operation: Unable to verify secret hash for client <cleint_id>
```