### PR TITLE
Bump python-jose to 3.2.0 to avoid loading ecdsa

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         "boto3>=1.10.49",
         "envs>=1.3",
-        "python-jose[cryptography]>=3.1.0",
+        "python-jose[cryptography]>=3.2.0",
         "requests>=2.22.0",
     ],
     include_package_data=True,


### PR DESCRIPTION
Supports https://github.com/home-assistant/core/pull/38056