### PR TITLE
Use same username as challenge parameters

### DIFF
--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -288,10 +288,12 @@ class AWSSRP:
 
             if tokens["ChallengeName"] == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
                 challenge_parameters = response["ChallengeParameters"]
-                challenge_response.update({
-                    "USERNAME": challenge_parameters['USERNAME'],
-                    "NEW_PASSWORD": new_password
-                })
+                challenge_response.update(
+                    {
+                        "USERNAME": challenge_parameters["USERNAME"],
+                        "NEW_PASSWORD": new_password,
+                    }
+                )
                 new_password_response = boto_client.respond_to_auth_challenge(
                     ClientId=self.client_id,
                     ChallengeName=self.NEW_PASSWORD_REQUIRED_CHALLENGE,

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -288,7 +288,10 @@ class AWSSRP:
 
             if tokens["ChallengeName"] == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
                 challenge_response.update(
-                    {"USERNAME": response["ChallengeParameters"]['USERNAME'], "NEW_PASSWORD": new_password}
+                    {
+                        "USERNAME": response["ChallengeParameters"]['USERNAME'],
+                        "NEW_PASSWORD": new_password
+                    }
                 )
                 new_password_response = boto_client.respond_to_auth_challenge(
                     ClientId=self.client_id,

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -287,12 +287,11 @@ class AWSSRP:
             )
 
             if tokens["ChallengeName"] == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
-                challenge_response.update(
-                    {
-                        "USERNAME": response["ChallengeParameters"]['USERNAME'],
-                        "NEW_PASSWORD": new_password
-                    }
-                )
+                challenge_parameters = response["ChallengeParameters"]
+                challenge_response.update({
+                    "USERNAME": challenge_parameters['USERNAME'],
+                    "NEW_PASSWORD": new_password
+                })
                 new_password_response = boto_client.respond_to_auth_challenge(
                     ClientId=self.client_id,
                     ChallengeName=self.NEW_PASSWORD_REQUIRED_CHALLENGE,

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -288,7 +288,7 @@ class AWSSRP:
 
             if tokens["ChallengeName"] == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
                 challenge_response.update(
-                    {"USERNAME": auth_params["USERNAME"], "NEW_PASSWORD": new_password}
+                    {"USERNAME": response["ChallengeParameters"]['USERNAME'], "NEW_PASSWORD": new_password}
                 )
                 new_password_response = boto_client.respond_to_auth_challenge(
                     ClientId=self.client_id,


### PR DESCRIPTION
This fixes an issue where the username in the auth initiate and the username returned in the challenge response did not match.

This is noted as an issue when using an email or some other alias to initiate the change password auth flow (specifically used after admin_create_user)  but the username returned in the challenge parameters is the actual username (ie sub) not the alias (ie email or phone).