### PR TITLE
Only update refresh_token if it was returned in the response

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -706,7 +706,8 @@ class Cognito:
         AuthenticationResult.
         """
         self.verify_token(tokens["AuthenticationResult"]["IdToken"], "id_token", "id")
-        self.refresh_token = tokens["AuthenticationResult"]["RefreshToken"]
+        if "RefreshToken" in tokens["AuthenticationResult"]:
+            self.refresh_token = tokens["AuthenticationResult"]["RefreshToken"]
         self.verify_token(
             tokens["AuthenticationResult"]["AccessToken"], "access_token", "access"
         )


### PR DESCRIPTION
It is not returned with renewals of the id and access token (which the documentation did not make clear).

This is another hotfix for a bug I introduced in 2021.2.1 that's still present in 2021.3.1. Apologies for the churn. I did not realize in my previous patches that the tests did not cover these code paths.