### PR TITLE
feat: Allow providing `ClientMetadata` in authentication

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -446,10 +446,11 @@ class Cognito:
         )
         self._set_tokens(tokens)
 
-    def authenticate(self, password):
+    def authenticate(self, password, client_metadata=None):
         """
         Authenticate the user using the SRP protocol
         :param password: The user's passsword
+        :param client_metadata: Metadata you can provide for custom workflows that RespondToAuthChallenge triggers.
         :return:
         """
         aws = AWSSRP(
@@ -460,7 +461,7 @@ class Cognito:
             client=self.client,
             client_secret=self.client_secret,
         )
-        tokens = aws.authenticate_user()
+        tokens = aws.authenticate_user(metadata=client_metadata)
         self._set_tokens(tokens)
 
     def new_password_challenge(self, password, new_password):

--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -461,7 +461,7 @@ class Cognito:
             client=self.client,
             client_secret=self.client_secret,
         )
-        tokens = aws.authenticate_user(metadata=client_metadata)
+        tokens = aws.authenticate_user(client_metadata=client_metadata)
         self._set_tokens(tokens)
 
     def new_password_challenge(self, password, new_password):

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -243,7 +243,7 @@ class AWSSRP:
             )
         return response
 
-    def authenticate_user(self, client=None, metadata=None):
+    def authenticate_user(self, client=None, client_metadata=None):
         boto_client = self.client or client
         auth_params = self.get_auth_params()
         response = boto_client.initiate_auth(
@@ -257,7 +257,7 @@ class AWSSRP:
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,
                 ChallengeResponses=challenge_response,
-                **dict(ClientMetadata=metadata) if metadata else {},
+                **dict(ClientMetadata=client_metadata) if client_metadata else {},
             )
 
             if tokens.get("ChallengeName") == self.NEW_PASSWORD_REQUIRED_CHALLENGE:

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -243,7 +243,7 @@ class AWSSRP:
             )
         return response
 
-    def authenticate_user(self, client=None):
+    def authenticate_user(self, client=None, metadata=None):
         boto_client = self.client or client
         auth_params = self.get_auth_params()
         response = boto_client.initiate_auth(
@@ -257,6 +257,7 @@ class AWSSRP:
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,
                 ChallengeResponses=challenge_response,
+                **dict(ClientMetadata=metadata) if metadata else {},
             )
 
             if tokens.get("ChallengeName") == self.NEW_PASSWORD_REQUIRED_CHALLENGE:

--- a/tests.py
+++ b/tests.py
@@ -19,7 +19,7 @@ from pycognito.aws_srp import AWSSRP
 from pycognito.utils import RequestsSrpAuth
 
 
-def _mock_authenticate_user(_, client=None, metadata=None):
+def _mock_authenticate_user(_, client=None, client_metadata=None):
     return {
         "AuthenticationResult": {
             "TokenType": "admin",

--- a/tests.py
+++ b/tests.py
@@ -19,7 +19,7 @@ from pycognito.aws_srp import AWSSRP
 from pycognito.utils import RequestsSrpAuth
 
 
-def _mock_authenticate_user(_, client=None):
+def _mock_authenticate_user(_, client=None, metadata=None):
     return {
         "AuthenticationResult": {
             "TokenType": "admin",


### PR DESCRIPTION
Useful when implementing Pre-Token Generation Lambdas, for instance.