### PR TITLE
fix: Generate timestamps independently from current locale

### DIFF
--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -4,7 +4,6 @@ import datetime
 import hashlib
 import hmac
 import os
-import re
 
 import boto3
 import six

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -33,6 +33,21 @@ N_HEX = (
 # https://github.com/aws/amazon-cognito-identity-js/blob/master/src/AuthenticationHelper.js#L49
 G_HEX = "2"
 INFO_BITS = bytearray("Caldera Derived Key", "utf-8")
+WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+MONTH_NAMES = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+]
 
 
 def hash_sha256(buf):
@@ -204,25 +219,9 @@ class AWSSRP:
 
     @staticmethod
     def get_cognito_formatted_timestamp(input_datetime):
-        weekday_names = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-        month_names = [
-            "Jan",
-            "Feb",
-            "Mar",
-            "Apr",
-            "May",
-            "Jun",
-            "Jul",
-            "Aug",
-            "Sep",
-            "Oct",
-            "Nov",
-            "Dec",
-        ]
-
         return "%s %s %d %02d:%02d:%02d UTC %d" % (
-            weekday_names[input_datetime.weekday()],
-            month_names[input_datetime.month - 1],
+            WEEKDAY_NAMES[input_datetime.weekday()],
+            MONTH_NAMES[input_datetime.month - 1],
             input_datetime.day,
             input_datetime.hour,
             input_datetime.minute,

--- a/tests.py
+++ b/tests.py
@@ -364,6 +364,35 @@ class AWSSRPTestCase(unittest.TestCase):
             self.assertTrue("RefreshToken" in tokens["AuthenticationResult"])
             stub.assert_no_pending_responses()
 
+    def test_cognito_formatted_timestamp(self):
+        self.assertEqual(
+            self.aws.get_cognito_formatted_timestamp(
+                datetime.datetime(2022, 1, 1, 0, 0, 0)
+            ),
+            "Sat Jan 1 00:00:00 UTC 2022",
+        )
+
+        self.assertEqual(
+            self.aws.get_cognito_formatted_timestamp(
+                datetime.datetime(2022, 1, 2, 12, 0, 0)
+            ),
+            "Sun Jan 2 12:00:00 UTC 2022",
+        )
+
+        self.assertEqual(
+            self.aws.get_cognito_formatted_timestamp(
+                datetime.datetime(2022, 1, 3, 9, 0, 0)
+            ),
+            "Mon Jan 3 09:00:00 UTC 2022",
+        )
+
+        self.assertEqual(
+            self.aws.get_cognito_formatted_timestamp(
+                datetime.datetime(2022, 12, 31, 23, 59, 59)
+            ),
+            "Sat Dec 31 23:59:59 UTC 2022",
+        )
+
 
 @moto.mock_cognitoidp
 class UtilsTestCase(unittest.TestCase):


### PR DESCRIPTION
Inspired by wsgiref.handlers.format_date_time().

Fixes #122 