### PR TITLE
[#66] Allow admin_create_user to let Cognito create a temporary password

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -607,7 +607,7 @@ class Cognito:
         Create a user using admin super privileges.
         :param username: User Pool username
         :param temporary_password: The temporary password to give the user.
-        Leave blank to make Cognito generate a temporary password for the user.
+        Pass None or omit this to make Cognito generate a temporary password for the user.
         :param additional_kwargs: Dictionary with request params, such as MessageAction.
         :param attr_map: Attribute map to Cognito's attributes
         :param kwargs: Additional User Pool attributes
@@ -615,11 +615,12 @@ class Cognito:
         """
         if additional_kwargs is None:
             additional_kwargs = {}
+        if temporary_password:
+            additional_kwargs["TemporaryPassword"] = temporary_password
         response = self.client.admin_create_user(
             UserPoolId=self.user_pool_id,
             Username=username,
             UserAttributes=dict_to_cognito(kwargs, attr_map),
-            TemporaryPassword=temporary_password,
             **additional_kwargs,
         )
         kwargs.update(username=username)


### PR DESCRIPTION
This addresses #66 by only adding `TemporaryPassword` conditionally to `additional_kwargs`. I've verified that Cognito is now successfully creating the user, and also generating a compliant password when `admin_create_user` is called with no `temporary_password` parameter, and also when `temporary_password` is `None`.

Two details:

1. If the user happened to pass both `TemporaryPassword` in the `additional_kwargs` dictionary and also the `temporary_password` parameter, then this value would be overridden. However, I'm not sure what a user would expect to happen in that case. It seems reasonable to coalesce the values, and we have to choose one of them anyway.
2. The user can also pass an empty string, since that's falsy in Python. Indeed, I've left the default argument value alone for this reason.