### PR TITLE
[#107] Provide a valid default for client_metadata in admin_reset_user_password

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -682,6 +682,8 @@ class Cognito:
         )
 
     def admin_reset_password(self, username, client_metadata=None):
+        if client_metadata is None:
+            client_metadata = {}
         self.client.admin_reset_user_password(
             UserPoolId=self.user_pool_id,
             Username=username,


### PR DESCRIPTION
I've followed the code pattern used elsewhere in the file for testing for missing function parameters.