### PR TITLE
Use endpoint url for generating pool url

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -195,6 +195,8 @@ class Cognito:
         if access_key and secret_key:
             boto3_client_kwargs["aws_access_key_id"] = access_key
             boto3_client_kwargs["aws_secret_access_key"] = secret_key
+        self.pool_domain_url = boto3_client_kwargs.get("endpoint_url", None)
+
         if self.user_pool_region:
             boto3_client_kwargs["region_name"] = self.user_pool_region
         if botocore_config:
@@ -207,6 +209,9 @@ class Cognito:
 
     @property
     def user_pool_url(self):
+        if self.pool_domain_url:
+            return f"{self.pool_domain_url}/{self.user_pool_id}"
+
         return f"https://cognito-idp.{self.user_pool_region}.amazonaws.com/{self.user_pool_id}"
 
     def get_keys(self):

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -226,7 +226,9 @@ class AWSSRP:
         return f"{WEEKDAY_NAMES[input_datetime.weekday()]} {MONTH_NAMES[input_datetime.month - 1]} {input_datetime.day:d} {input_datetime.hour:02d}:{input_datetime.minute:02d}:{input_datetime.second:02d} UTC {input_datetime.year:d}"
 
     def process_challenge(self, challenge_parameters, request_parameters):
-        internal_username = challenge_parameters.get("USERNAME", request_parameters["USERNAME"])
+        internal_username = challenge_parameters.get(
+            "USERNAME", request_parameters["USERNAME"]
+        )
         user_id_for_srp = challenge_parameters["USER_ID_FOR_SRP"]
         salt_hex = challenge_parameters["SALT"]
         srp_b_hex = challenge_parameters["SRP_B"]
@@ -270,7 +272,9 @@ class AWSSRP:
             ClientId=self.client_id,
         )
         if response["ChallengeName"] == self.PASSWORD_VERIFIER_CHALLENGE:
-            challenge_response = self.process_challenge(response["ChallengeParameters"], auth_params)
+            challenge_response = self.process_challenge(
+                response["ChallengeParameters"], auth_params
+            )
             tokens = boto_client.respond_to_auth_challenge(
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,
@@ -306,7 +310,9 @@ class AWSSRP:
             ClientId=self.client_id,
         )
         if response["ChallengeName"] == self.PASSWORD_VERIFIER_CHALLENGE:
-            challenge_response = self.process_challenge(response["ChallengeParameters"], auth_params)
+            challenge_response = self.process_challenge(
+                response["ChallengeParameters"], auth_params
+            )
             tokens = boto_client.respond_to_auth_challenge(
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -225,8 +225,8 @@ class AWSSRP:
     def get_cognito_formatted_timestamp(input_datetime):
         return f"{WEEKDAY_NAMES[input_datetime.weekday()]} {MONTH_NAMES[input_datetime.month - 1]} {input_datetime.day:d} {input_datetime.hour:02d}:{input_datetime.minute:02d}:{input_datetime.second:02d} UTC {input_datetime.year:d}"
 
-    def process_challenge(self, challenge_parameters):
-        internal_username = challenge_parameters.get("USERNAME", self.username)
+    def process_challenge(self, challenge_parameters, request_parameters):
+        internal_username = challenge_parameters.get("USERNAME", request_parameters["USERNAME"])
         user_id_for_srp = challenge_parameters["USER_ID_FOR_SRP"]
         salt_hex = challenge_parameters["SALT"]
         srp_b_hex = challenge_parameters["SRP_B"]
@@ -270,7 +270,7 @@ class AWSSRP:
             ClientId=self.client_id,
         )
         if response["ChallengeName"] == self.PASSWORD_VERIFIER_CHALLENGE:
-            challenge_response = self.process_challenge(response["ChallengeParameters"])
+            challenge_response = self.process_challenge(response["ChallengeParameters"], auth_params)
             tokens = boto_client.respond_to_auth_challenge(
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,
@@ -306,7 +306,7 @@ class AWSSRP:
             ClientId=self.client_id,
         )
         if response["ChallengeName"] == self.PASSWORD_VERIFIER_CHALLENGE:
-            challenge_response = self.process_challenge(response["ChallengeParameters"])
+            challenge_response = self.process_challenge(response["ChallengeParameters"], auth_params)
             tokens = boto_client.respond_to_auth_challenge(
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,

--- a/pycognito/aws_srp.py
+++ b/pycognito/aws_srp.py
@@ -226,7 +226,7 @@ class AWSSRP:
         return f"{WEEKDAY_NAMES[input_datetime.weekday()]} {MONTH_NAMES[input_datetime.month - 1]} {input_datetime.day:d} {input_datetime.hour:02d}:{input_datetime.minute:02d}:{input_datetime.second:02d} UTC {input_datetime.year:d}"
 
     def process_challenge(self, challenge_parameters):
-        internal_username = challenge_parameters["USERNAME"]
+        internal_username = challenge_parameters.get("USERNAME", self.username)
         user_id_for_srp = challenge_parameters["USER_ID_FOR_SRP"]
         salt_hex = challenge_parameters["SALT"]
         srp_b_hex = challenge_parameters["SRP_B"]


### PR DESCRIPTION
This handles the scenario where the issuer of the token will not match the pool url if a custom endpoint_url is used

Also fixed an issue where the USERNAME may not be provided as part of the ChallengeParameters response as it is optional according to the Cognito docs.
LocalStack Cognito authoriser does not provide the USERNAME as part of the ChallengeParameters

 