### PR TITLE
Fix test_check_token failure on systems with 32-bit time_t

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -213,7 +213,12 @@ class CognitoAuthTestCase(unittest.TestCase):
             "9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjMyNTAzNjgwMDAwfQ.C-1gPxrhUsiWeCvMvaZuuQYarkDNAc"
             "pEGJPIqu_SrKQ"
         )
-        self.assertFalse(self.user.check_token())
+        try:
+            valid = self.user.check_token()
+        except OverflowError:
+            self.skipTest("This test requires 64-bit time_t")
+        else:
+            self.assertFalse(valid)
 
     @patch("pycognito.Cognito", autospec=True)
     def test_validate_verification(self, cognito_user):


### PR DESCRIPTION
Skip tests if OverflowError is raised.
This is a known limitation of Python on 32-bit platforms (https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp).

Catching OverflowError is the best option here since some 32-bit platforms (e.g. NetBSD) use 64-bit time_t, and others are working on providing a switch to the 64-bit type (e.g. glibc).